### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 on:
   - push
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/RoboJackets/loop-workday-upload/security/code-scanning/3](https://github.com/RoboJackets/loop-workday-upload/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow file to limit GitHub token permissions to those strictly required by this workflow. As nothing in the steps needs write access to repo contents (no artifacts are uploaded, no releases are created, etc.), set `contents: read` at the workflow (root) level. Insert the following block right after the `name: Build` line in `.github/workflows/build.yml`. No imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
